### PR TITLE
feat: add interactive terminal chat and session history

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,7 +5,7 @@ const config: Config = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx'],
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
 };
 

--- a/package.json
+++ b/package.json
@@ -29,15 +29,17 @@
   "author": "",
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
-    "axios": "^1.12.2",
     "commander": "^14.0.1",
     "dotenv": "^17.2.3",
     "ink": "^6.3.1",
+    "openai": "^4.80.1",
     "pino": "^10.0.0",
+    "pino-pretty": "^11.3.0",
     "react": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",
+    "@types/react": "^19.0.8",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.6.2",
     "@typescript-eslint/eslint-plugin": "^8.45.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      axios:
-        specifier: ^1.12.2
-        version: 1.12.2
       commander:
         specifier: ^14.0.1
         version: 14.0.1
@@ -19,10 +16,16 @@ importers:
         version: 17.2.3
       ink:
         specifier: ^6.3.1
-        version: 6.3.1(react@19.2.0)
+        version: 6.3.1(@types/react@19.2.0)(react@19.2.0)
+      openai:
+        specifier: ^4.80.1
+        version: 4.104.0(ws@8.18.3)
       pino:
         specifier: ^10.0.0
         version: 10.0.0
+      pino-pretty:
+        specifier: ^11.3.0
+        version: 11.3.0
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -36,6 +39,9 @@ importers:
       '@types/node':
         specifier: ^24.6.2
         version: 24.6.2
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.45.0
         version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0)(typescript@5.9.3))(eslint@9.37.0)(typescript@5.9.3)
@@ -514,8 +520,17 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.129':
+    resolution: {integrity: sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==}
+
   '@types/node@24.6.2':
     resolution: {integrity: sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==}
+
+  '@types/react@19.2.0':
+    resolution: {integrity: sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -683,6 +698,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -696,6 +715,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -784,9 +807,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
-
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -835,6 +855,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.8.12:
     resolution: {integrity: sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==}
     hasBin: true
@@ -863,6 +886,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -989,6 +1015,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1000,6 +1029,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -1081,6 +1113,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1255,8 +1290,16 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -1269,6 +1312,9 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1285,6 +1331,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1324,22 +1373,20 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1460,6 +1507,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1467,10 +1517,16 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1827,6 +1883,10 @@ packages:
       node-notifier:
         optional: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1981,6 +2041,20 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -2033,6 +2107,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2108,6 +2194,10 @@ packages:
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
+  pino-pretty@11.3.0:
+    resolution: {integrity: sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==}
+    hasBin: true
+
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
@@ -2147,12 +2237,16 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2179,6 +2273,10 @@ packages:
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -2242,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -2256,6 +2357,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2388,6 +2492,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2445,6 +2552,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2552,6 +2662,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.13.0:
     resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
 
@@ -2576,6 +2689,16 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3278,9 +3401,22 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.6.2
+      form-data: 4.0.4
+
+  '@types/node@18.19.129':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@24.6.2':
     dependencies:
       undici-types: 7.13.0
+
+  '@types/react@19.2.0':
+    dependencies:
+      csstype: 3.1.3
 
   '@types/stack-utils@2.0.3': {}
 
@@ -3445,6 +3581,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3454,6 +3594,10 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv@6.12.6:
     dependencies:
@@ -3557,14 +3701,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.12.2:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   babel-jest@29.7.0(@babel/core@7.28.4):
     dependencies:
       '@babel/core': 7.28.4
@@ -3659,6 +3795,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.8.12: {}
 
   brace-expansion@1.1.12:
@@ -3691,6 +3829,11 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3810,6 +3953,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.1.3: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -3827,6 +3972,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dateformat@4.6.3: {}
 
   debug@3.2.7:
     dependencies:
@@ -3881,6 +4028,10 @@ snapshots:
   emoji-regex@10.5.0: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   environment@1.1.0: {}
 
@@ -4130,7 +4281,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
+
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -4154,6 +4309,8 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -4169,6 +4326,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fastq@1.19.1:
     dependencies:
@@ -4207,11 +4366,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data-encoder@1.7.2: {}
 
   form-data@4.0.4:
     dependencies:
@@ -4220,6 +4379,11 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   fs.realpath@1.0.0: {}
 
@@ -4340,11 +4504,19 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   html-escaper@2.0.2: {}
 
   human-signals@2.1.0: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   husky@9.1.7: {}
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -4371,7 +4543,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink@6.3.1(react@19.2.0):
+  ink@6.3.1(@types/react@19.2.0)(react@19.2.0):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.0
       ansi-escapes: 7.1.1
@@ -4397,6 +4569,8 @@ snapshots:
       wrap-ansi: 9.0.2
       ws: 8.18.3
       yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4927,6 +5101,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -5063,6 +5239,12 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.23: {}
@@ -5119,6 +5301,20 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@4.104.0(ws@8.18.3):
+    dependencies:
+      '@types/node': 18.19.129
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -5186,6 +5382,23 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pino-pretty@11.3.0:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.3
+      readable-stream: 4.7.0
+      secure-json-parse: 2.7.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 3.1.1
+
   pino-std-serializers@7.0.0: {}
 
   pino@10.0.0:
@@ -5226,12 +5439,17 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  process@0.11.10: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  proxy-from-env@1.1.0: {}
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -5249,6 +5467,14 @@ snapshots:
       scheduler: 0.26.0
 
   react@19.2.0: {}
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   real-require@0.2.0: {}
 
@@ -5318,6 +5544,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -5332,6 +5560,8 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   scheduler@0.26.0: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@6.3.1: {}
 
@@ -5486,6 +5716,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5536,6 +5770,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tr46@0.0.3: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -5655,6 +5891,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@7.13.0: {}
 
   unrs-resolver@1.11.1:
@@ -5702,6 +5940,15 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import { Command } from 'commander';
+
+import { DeepSeekClient } from '../../api/deepseekClient';
+import { getApiConfig, getHistoryDir } from '../../config';
+import { ChatController } from '../../controllers/chatController';
+import { SessionFsRepository } from '../../core/repository/sessionFsRepository';
+import { EventBus } from '../../core/services/eventBus';
+import { startTui } from '../../tui';
+
+export const chat = new Command('chat')
+  .description('start interactive terminal chat')
+  .option('-m, --model <name>', 'model name to use')
+  .action(async (options: { model?: string }) => {
+    const { model } = options;
+    const apiKey = process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      console.error('DEEPSEEK_API_KEY is not set. Please configure it in your environment.');
+      process.exitCode = 1;
+      return;
+    }
+
+    const apiConfig = getApiConfig();
+    const historyDir = path.resolve(process.cwd(), getHistoryDir());
+    const selectedModel = model ?? apiConfig.model;
+
+    const controller = new ChatController(
+      new DeepSeekClient(apiKey, apiConfig.baseUrl, selectedModel),
+      new SessionFsRepository(historyDir),
+      process.cwd(),
+      selectedModel,
+      new EventBus(),
+    );
+
+    const session = await controller.startSession();
+    await startTui(controller, session);
+  });

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -1,0 +1,54 @@
+import path from 'path';
+import { Command } from 'commander';
+
+import { DeepSeekClient } from '../../api/deepseekClient';
+import { getApiConfig, getHistoryDir } from '../../config';
+import { ChatController } from '../../controllers/chatController';
+import { SessionFsRepository } from '../../core/repository/sessionFsRepository';
+import { EventBus } from '../../core/services/eventBus';
+import { startTui } from '../../tui';
+
+export const resume = new Command('resume')
+  .description('resume last or specific session')
+  .option('--last', 'resume last session')
+  .argument('[id]', 'session id')
+  .action(async (id: string | undefined, options: { last?: boolean }) => {
+    const { last } = options;
+    const apiKey = process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) {
+      console.error('DEEPSEEK_API_KEY is not set. Please configure it in your environment.');
+      process.exitCode = 1;
+      return;
+    }
+
+    const apiConfig = getApiConfig();
+    const historyDir = path.resolve(process.cwd(), getHistoryDir());
+    const repo = new SessionFsRepository(historyDir);
+
+    const targetId = last ? await repo.lastSessionId() : id;
+    if (!targetId) {
+      console.error('No session to resume');
+      process.exitCode = 1;
+      return;
+    }
+
+    const snapshot = await repo.readSnapshot(targetId);
+    if (!snapshot) {
+      console.error(`Snapshot for session ${targetId} not found`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const controller = new ChatController(
+      new DeepSeekClient(apiKey, apiConfig.baseUrl, snapshot.model),
+      repo,
+      process.cwd(),
+      snapshot.model,
+      new EventBus(),
+    );
+
+    controller.eventBus.emit('session', snapshot);
+    controller.eventBus.emit('status', { state: 'idle' });
+
+    await startTui(controller, snapshot);
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,8 @@
 import { Command } from 'commander';
 import dotenv from 'dotenv';
 
-import { DeepSeekClient } from '../api/deepseekClient';
+import { chat } from './commands/chat';
+import { resume } from './commands/resume';
 import { logger } from '../utils/logger';
 
 dotenv.config();
@@ -10,48 +11,12 @@ dotenv.config();
 const program = new Command();
 
 program.name('deepseek').description('DeepSeek command line interface').version('0.1.0');
+program.addCommand(chat);
+program.addCommand(resume);
 
-program
-  .command('hello')
-  .description('Verify DeepSeek CLI initialization')
-  .action(() => {
-    logger.info('DeepSeek CLI initialized successfully');
-    console.log('DeepSeek CLI initialized successfully');
-  });
-
-program
-  .command('test-api')
-  .description('Send a test message to DeepSeek API')
-  .action(async () => {
-    const apiKey = process.env.DEEPSEEK_API_KEY;
-
-    if (!apiKey) {
-      logger.error('DEEPSEEK_API_KEY is not set');
-      console.error('DEEPSEEK_API_KEY is not set. Please configure it in your environment.');
-      process.exitCode = 1;
-      return;
-    }
-
-    try {
-      const client = new DeepSeekClient(apiKey);
-      const response = await client.send([
-        {
-          role: 'user',
-          content: 'ping',
-        },
-      ]);
-      logger.info({ response }, 'Received response from DeepSeek API');
-      console.log('DeepSeek API response:', response.content);
-      console.log('Tokens used:', response.tokensUsed);
-    } catch (error) {
-      logger.error({ err: error }, 'Failed to communicate with DeepSeek API');
-      console.error('Failed to communicate with DeepSeek API:', (error as Error).message);
-      process.exitCode = 1;
-    }
-  });
-
-program.parseAsync(process.argv).catch((error) => {
-  logger.error({ err: error }, 'Failed to execute DeepSeek CLI command');
-  console.error('Failed to execute DeepSeek CLI command:', (error as Error).message);
+program.parseAsync(process.argv).catch((error: unknown) => {
+  const err = error as Error;
+  logger.error({ err }, 'Failed to execute DeepSeek CLI command');
+  console.error('Failed to execute DeepSeek CLI command:', err.message);
   process.exit(1);
 });

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -4,6 +4,7 @@
     "model": "deepseek-chat"
   },
   "logging": {
-    "level": "info"
-  }
+    "level": "debug"
+  },
+  "historyDir": "history"
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,7 @@ export interface ApiConfig {
 export interface AppConfig {
   api: ApiConfig;
   logging: LoggingConfig;
+  historyDir: string;
 }
 
 const appConfig: AppConfig = defaultConfig as AppConfig;
@@ -21,3 +22,5 @@ export const getConfig = (): AppConfig => appConfig;
 export const getApiConfig = (): ApiConfig => appConfig.api;
 
 export const getLoggingConfig = (): LoggingConfig => appConfig.logging;
+
+export const getHistoryDir = (): string => appConfig.historyDir;

--- a/src/controllers/chatController.ts
+++ b/src/controllers/chatController.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from 'node:crypto';
+import { DeepSeekClient, ChatMessage } from '../api/deepseekClient';
+import { Message } from '../core/models/message';
+import { Session } from '../core/models/session';
+import { SessionFsRepository } from '../core/repository/sessionFsRepository';
+import { loadAgentsDoc } from '../core/services/agentsDocLoader';
+import { EventBus } from '../core/services/eventBus';
+import { logger } from '../utils/logger';
+
+function cloneMessage(message?: Message): Message | undefined {
+  if (!message) {
+    return undefined;
+  }
+  return { ...message };
+}
+
+function cloneSession(session: Session): Session {
+  return {
+    ...session,
+    messages: session.messages.map(cloneMessage) as Message[],
+    turns: session.turns.map((turn) => ({
+      ...turn,
+      user: cloneMessage(turn.user),
+      assistant: cloneMessage(turn.assistant),
+    })),
+    meta: session.meta ? { ...session.meta } : undefined,
+  };
+}
+
+function toChatMessages(messages: Message[]): ChatMessage[] {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+}
+
+export class ChatController {
+  constructor(
+    private readonly client: DeepSeekClient,
+    private readonly repo: SessionFsRepository,
+    private readonly cwd: string,
+    private readonly model: string,
+    private readonly events: EventBus,
+    private readonly agentsLoader: typeof loadAgentsDoc = loadAgentsDoc,
+  ) {}
+
+  get eventBus() {
+    return this.events;
+  }
+
+  async startSession(): Promise<Session> {
+    const now = Date.now();
+    const id = randomUUID();
+    const systemPrompt = await this.agentsLoader(this.cwd);
+    const session: Session = {
+      id,
+      model: this.model,
+      createdAt: now,
+      messages: [],
+      turns: [],
+      meta: { cwd: this.cwd },
+    };
+
+    if (systemPrompt.trim()) {
+      const systemMessage: Message = {
+        id: randomUUID(),
+        role: 'system',
+        content: systemPrompt,
+        ts: Date.now(),
+      };
+      session.messages.push(systemMessage);
+    }
+
+    await this.repo.saveSnapshot(session);
+    await this.repo.append(session.id, { type: 'session.started', model: this.model, ts: Date.now() });
+
+    logger.debug({ sessionId: session.id, model: this.model }, 'Session started');
+    this.events.emit('session', session);
+    this.events.emit('status', { state: 'idle' });
+    return session;
+  }
+
+  async send(current: Session, userText: string): Promise<Session> {
+    const session = cloneSession(current);
+    const ts = Date.now();
+    const user: Message = { id: randomUUID(), role: 'user', content: userText, ts };
+    session.messages = [...session.messages, user];
+
+    Object.assign(current, session);
+    current.messages = session.messages;
+    current.turns = session.turns;
+    current.meta = session.meta;
+
+    await this.repo.append(session.id, { type: 'item.user', message: user, ts });
+    this.events.emit('message', user);
+    this.events.emit('session', session);
+    this.events.emit('status', { state: 'sending' });
+
+    logger.debug({ sessionId: session.id, userMessageId: user.id }, 'Sending message to DeepSeek');
+
+    try {
+      const { content } = await this.client.chat(toChatMessages(session.messages));
+      const now = Date.now();
+      const assistant: Message = {
+        id: randomUUID(),
+        role: 'assistant',
+        content,
+        ts: now,
+      };
+
+      session.messages = [...session.messages, assistant];
+      session.turns = [
+        ...session.turns,
+        {
+          id: randomUUID(),
+          user,
+          assistant,
+          ts: now,
+        },
+      ];
+
+      await this.repo.append(session.id, { type: 'item.assistant', message: assistant, ts: now });
+      await this.repo.saveSnapshot(session);
+
+      current.messages = session.messages;
+      current.turns = session.turns;
+      current.meta = session.meta;
+
+      this.events.emit('message', assistant);
+      this.events.emit('session', session);
+      this.events.emit('status', { state: 'idle' });
+
+      logger.debug({ sessionId: session.id, assistantMessageId: assistant.id }, 'Received response from DeepSeek');
+      return session;
+    } catch (error) {
+      const err = error as Error;
+      Object.assign(current, session);
+      current.messages = session.messages;
+      current.turns = session.turns;
+      current.meta = session.meta;
+      this.events.emit('status', { state: 'error', message: err.message });
+      this.events.emit('error', { error: err });
+      logger.error({ err, sessionId: session.id }, 'Failed to get response from DeepSeek');
+      throw err;
+    }
+  }
+}

--- a/src/core/models/message.ts
+++ b/src/core/models/message.ts
@@ -1,0 +1,8 @@
+export type Role = 'system' | 'user' | 'assistant';
+
+export interface Message {
+  id: string;
+  role: Role;
+  content: string;
+  ts: number;
+}

--- a/src/core/models/session.ts
+++ b/src/core/models/session.ts
@@ -1,0 +1,11 @@
+import { Message } from './message';
+import { Turn } from './turn';
+
+export interface Session {
+  id: string;
+  model: string;
+  createdAt: number;
+  messages: Message[];
+  turns: Turn[];
+  meta?: Record<string, unknown>;
+}

--- a/src/core/models/turn.ts
+++ b/src/core/models/turn.ts
@@ -1,0 +1,8 @@
+import { Message } from './message';
+
+export interface Turn {
+  id: string;
+  user?: Message;
+  assistant?: Message;
+  ts: number;
+}

--- a/src/core/repository/sessionFsRepository.ts
+++ b/src/core/repository/sessionFsRepository.ts
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { Session } from '../models/session';
+
+export class SessionFsRepository {
+  constructor(private readonly baseDir: string) {}
+
+  private p(id: string) {
+    return path.join(this.baseDir, `${id}.jsonl`);
+  }
+
+  private snap(id: string) {
+    return path.join(this.baseDir, `${id}.snapshot.json`);
+  }
+
+  async append(id: string, record: unknown) {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    await fs.appendFile(this.p(id), JSON.stringify(record) + '\n', 'utf-8');
+  }
+
+  async saveSnapshot(session: Session) {
+    await fs.mkdir(this.baseDir, { recursive: true });
+    await fs.writeFile(this.snap(session.id), JSON.stringify(session, null, 2), 'utf-8');
+  }
+
+  async readSnapshot(id: string): Promise<Session | null> {
+    try {
+      const content = await fs.readFile(this.snap(id), 'utf-8');
+      return JSON.parse(content) as Session;
+    } catch {
+      return null;
+    }
+  }
+
+  async lastSessionId(): Promise<string | null> {
+    try {
+      const files = (await fs.readdir(this.baseDir)).filter((f) => f.endsWith('.snapshot.json'));
+      if (!files.length) {
+        return null;
+      }
+      files.sort((a, b) => a.localeCompare(b));
+      return files.pop()!.replace('.snapshot.json', '');
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/core/services/agentsDocLoader.ts
+++ b/src/core/services/agentsDocLoader.ts
@@ -1,0 +1,15 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function loadAgentsDoc(cwd: string, home = process.env.HOME ?? '') {
+  const paths = [path.join(home, '.deepseek', 'AGENTS.md'), path.join(cwd, 'AGENTS.md')];
+  const parts: string[] = [];
+  for (const p of paths) {
+    try {
+      parts.push(await fs.readFile(p, 'utf-8'));
+    } catch {
+      // ignore missing files
+    }
+  }
+  return parts.join('\n\n---\n\n');
+}

--- a/src/core/services/eventBus.ts
+++ b/src/core/services/eventBus.ts
@@ -1,0 +1,38 @@
+import { EventEmitter } from 'node:events';
+
+import { Message } from '../models/message';
+import { Session } from '../models/session';
+
+export type StatusState = 'idle' | 'sending' | 'error';
+
+export interface StatusEvent {
+  state: StatusState;
+  message?: string;
+}
+
+export type ChatEventMap = {
+  status: StatusEvent;
+  session: Session;
+  message: Message;
+  error: { error: Error };
+};
+
+type Listener<T> = (payload: T) => void;
+
+export class EventBus {
+  private readonly emitter = new EventEmitter();
+
+  on<K extends keyof ChatEventMap>(event: K, listener: Listener<ChatEventMap[K]>) {
+    this.emitter.on(event, listener);
+    return () => this.emitter.off(event, listener);
+  }
+
+  once<K extends keyof ChatEventMap>(event: K, listener: Listener<ChatEventMap[K]>) {
+    this.emitter.once(event, listener);
+    return () => this.emitter.off(event, listener);
+  }
+
+  emit<K extends keyof ChatEventMap>(event: K, payload: ChatEventMap[K]) {
+    this.emitter.emit(event, payload);
+  }
+}

--- a/src/tui/components/Chat.tsx
+++ b/src/tui/components/Chat.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+import { ChatController } from '../../controllers/chatController';
+import { Session } from '../../core/models/session';
+import { StatusState } from '../../core/services/eventBus';
+import { MessageList } from './MessageList';
+import { StatusBar } from './StatusBar';
+
+export interface ChatProps {
+  controller: ChatController;
+  initialSession: Session;
+}
+
+export function Chat({ controller, initialSession }: ChatProps) {
+  const [session, setSession] = useState<Session>(initialSession);
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState<StatusState>('idle');
+  const [error, setError] = useState<string | undefined>();
+  const sessionRef = useRef(session);
+  const sendingRef = useRef(false);
+
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    setSession(initialSession);
+  }, [initialSession]);
+
+  useEffect(() => {
+    const unsubscribeStatus = controller.eventBus.on('status', (event) => {
+      setStatus(event.state);
+      setError(event.message);
+      if (event.state !== 'sending') {
+        sendingRef.current = false;
+      }
+    });
+    const unsubscribeSession = controller.eventBus.on('session', (updatedSession) => {
+      setSession(updatedSession);
+    });
+    return () => {
+      unsubscribeStatus();
+      unsubscribeSession();
+    };
+  }, [controller]);
+
+  const submit = async () => {
+    const text = input.trim();
+    if (!text || sendingRef.current) {
+      return;
+    }
+    sendingRef.current = true;
+    setInput('');
+    try {
+      await controller.send(sessionRef.current, text);
+      setError(undefined);
+    } catch (err) {
+      const e = err as Error;
+      setError(e.message);
+      sendingRef.current = false;
+    }
+  };
+
+  useInput((inputKey, key) => {
+    if (key.return) {
+      void submit();
+      return;
+    }
+    if (key.backspace || key.delete) {
+      setInput((value) => value.slice(0, -1));
+      return;
+    }
+    if (!key.ctrl && !key.meta && inputKey) {
+      setInput((value) => value + inputKey);
+    }
+  });
+
+  const cursor = status === 'sending' ? '' : '█';
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      <Text color="yellow">DeepSeek CLI — Interactive (Terminal)</Text>
+      <Box flexDirection="column" flexGrow={1} marginTop={1}>
+        <MessageList messages={session.messages} />
+      </Box>
+      <Box marginTop={1}>
+        <Text color="gray">› </Text>
+        <Text>{input}{cursor}</Text>
+      </Box>
+      <Box marginTop={1}>
+        <StatusBar sessionId={session.id} model={session.model} status={status} error={error} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/MessageList.tsx
+++ b/src/tui/components/MessageList.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { Message } from '../../core/models/message';
+
+const roleColors: Record<Message['role'], string> = {
+  system: 'yellow',
+  user: 'cyan',
+  assistant: 'green',
+};
+
+export interface MessageListProps {
+  messages: Message[];
+}
+
+export function MessageList({ messages }: MessageListProps) {
+  return (
+    <Box flexDirection="column">
+      {messages.map((message) => (
+        <Text key={message.id} color={roleColors[message.role]}>
+          {message.role.padEnd(9)}: {message.content}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { StatusState } from '../../core/services/eventBus';
+
+export interface StatusBarProps {
+  sessionId: string;
+  model: string;
+  status: StatusState;
+  error?: string;
+}
+
+const statusColor: Record<StatusState, string> = {
+  idle: 'gray',
+  sending: 'yellow',
+  error: 'red',
+};
+
+const statusLabel: Record<StatusState, string> = {
+  idle: 'Idle',
+  sending: 'Responding…',
+  error: 'Error',
+};
+
+export function StatusBar({ sessionId, model, status, error }: StatusBarProps) {
+  return (
+    <Box justifyContent="space-between" borderStyle="round" borderColor="gray" paddingX={1}>
+      <Text color="gray">Session: {sessionId}</Text>
+      <Text color="gray">Model: {model}</Text>
+      <Text color={statusColor[status]}>
+        {statusLabel[status]}
+        {status === 'error' && error ? ` — ${error}` : ''}
+      </Text>
+    </Box>
+  );
+}

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'ink';
+
+import { ChatController } from '../controllers/chatController';
+import { Session } from '../core/models/session';
+import { Chat } from './components/Chat';
+
+export async function startTui(controller: ChatController, initialSession: Session) {
+  const app = render(<Chat controller={controller} initialSession={initialSession} />);
+  await app.waitUntilExit();
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,6 +7,13 @@ const loggingConfig = getLoggingConfig();
 export const logger = pino({
   level: loggingConfig.level,
   name: 'deepseek-cli',
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true,
+      translateTime: 'SYS:standard',
+    },
+  },
 });
 
 export type Logger = typeof logger;

--- a/tests/chatController.test.ts
+++ b/tests/chatController.test.ts
@@ -1,0 +1,95 @@
+import { ChatController } from '../src/controllers/chatController';
+import { DeepSeekClient } from '../src/api/deepseekClient';
+import { SessionFsRepository } from '../src/core/repository/sessionFsRepository';
+import { EventBus, StatusEvent } from '../src/core/services/eventBus';
+
+jest.mock('../src/utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('ChatController', () => {
+  let client: { chat: jest.Mock };
+  let repo: {
+    append: jest.Mock;
+    saveSnapshot: jest.Mock;
+    readSnapshot: jest.Mock;
+    lastSessionId: jest.Mock;
+  };
+  let eventBus: EventBus;
+  let loader: jest.Mock;
+
+  beforeEach(() => {
+    client = {
+      chat: jest.fn(),
+    };
+    repo = {
+      append: jest.fn().mockResolvedValue(undefined),
+      saveSnapshot: jest.fn().mockResolvedValue(undefined),
+      readSnapshot: jest.fn(),
+      lastSessionId: jest.fn(),
+    };
+    eventBus = new EventBus();
+    loader = jest.fn().mockResolvedValue('System instructions');
+  });
+
+  it('starts a session with system prompt from agents loader', async () => {
+    const controller = new ChatController(
+      client as unknown as DeepSeekClient,
+      repo as unknown as SessionFsRepository,
+      '/tmp/project',
+      'deepseek-chat',
+      eventBus,
+      loader,
+    );
+
+    const session = await controller.startSession();
+
+    expect(loader).toHaveBeenCalledWith('/tmp/project');
+    expect(repo.saveSnapshot).toHaveBeenCalledWith(session);
+    expect(repo.append).toHaveBeenCalledWith(session.id, expect.objectContaining({ type: 'session.started' }));
+    expect(session.messages[0]).toMatchObject({ role: 'system', content: 'System instructions' });
+  });
+
+  it('sends user messages, stores assistant responses and emits status events', async () => {
+    client.chat.mockResolvedValue({ content: 'Hello from DeepSeek' });
+
+    const controller = new ChatController(
+      client as unknown as DeepSeekClient,
+      repo as unknown as SessionFsRepository,
+      '/tmp/project',
+      'deepseek-chat',
+      eventBus,
+      loader,
+    );
+
+    const session = await controller.startSession();
+    repo.append.mockClear();
+    repo.saveSnapshot.mockClear();
+
+    const statuses: StatusEvent['state'][] = [];
+    eventBus.on('status', (event) => {
+      statuses.push(event.state);
+    });
+
+    const updated = await controller.send(session, 'Hi there');
+
+    expect(client.chat).toHaveBeenCalledTimes(1);
+    expect(client.chat).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: 'Hi there' }),
+      ]),
+    );
+
+    expect(repo.append).toHaveBeenNthCalledWith(1, session.id, expect.objectContaining({ type: 'item.user' }));
+    expect(repo.append).toHaveBeenNthCalledWith(2, session.id, expect.objectContaining({ type: 'item.assistant' }));
+    expect(repo.saveSnapshot).toHaveBeenCalledWith(updated);
+
+    expect(updated.messages.filter((m) => m.role === 'assistant')).toHaveLength(1);
+    expect(updated.turns).toHaveLength(1);
+    expect(statuses).toContain('sending');
+    expect(statuses).toContain('idle');
+  });
+});

--- a/tests/sessionFsRepository.test.ts
+++ b/tests/sessionFsRepository.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { SessionFsRepository } from '../src/core/repository/sessionFsRepository';
+import { Session } from '../src/core/models/session';
+
+function createSession(id: string): Session {
+  return {
+    id,
+    model: 'deepseek-chat',
+    createdAt: Date.now(),
+    messages: [],
+    turns: [],
+  };
+}
+
+describe('SessionFsRepository', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'session-repo-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('appends records as JSON lines', async () => {
+    const repo = new SessionFsRepository(dir);
+    await repo.append('test', { type: 'event', value: 1 });
+    await repo.append('test', { type: 'event', value: 2 });
+
+    const content = await fs.readFile(path.join(dir, 'test.jsonl'), 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({ type: 'event', value: 1 });
+    expect(JSON.parse(lines[1])).toEqual({ type: 'event', value: 2 });
+  });
+
+  it('saves and reads snapshots', async () => {
+    const repo = new SessionFsRepository(dir);
+    const session = createSession('abc');
+    await repo.saveSnapshot(session);
+
+    const snapshot = await repo.readSnapshot('abc');
+    expect(snapshot).toEqual(session);
+  });
+
+  it('returns the last session id', async () => {
+    const repo = new SessionFsRepository(dir);
+    await repo.saveSnapshot(createSession('001'));
+    await repo.saveSnapshot(createSession('002'));
+
+    const lastId = await repo.lastSessionId();
+    expect(lastId).toBe('002');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "esModuleInterop": true,
+    "jsx": "react-jsx",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- implement an Ink-powered TUI for DeepSeek chat with role highlighting, input handling, and status bar
- persist conversations to disk via a file-system session repository and load combined AGENTS instructions as the system prompt
- add CLI commands to start or resume sessions and cover controller/repository logic with tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e18a38eaac832382b2c0d82ad56794