### PR TITLE
Add sandbox controls and safe patch/exec workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DeepSeek CLI
 
-Command line interface for interacting with the DeepSeek API. This stage establishes the architectural
-foundation, tooling, and initial commands for the project.
+Command line interface for interacting with the DeepSeek API with built-in session management, sandboxed
+operations, approval flows, and safe patch/command execution utilities.
 
 ## Requirements
 
@@ -14,49 +14,88 @@ foundation, tooling, and initial commands for the project.
    ```bash
    pnpm install
    ```
-2. Copy the example environment variables and set your DeepSeek API key:
+2. Configure environment variables. At minimum export your DeepSeek API key:
    ```bash
-   cp .env .env.local # optional custom file
-   # edit .env or .env.local
+   export DEEPSEEK_API_KEY=<your-key>
    ```
-   Ensure `DEEPSEEK_API_KEY` is defined in your environment before running API commands. The CLI loads
-   variables from `.env` automatically.
+   The CLI automatically loads variables from `.env` if present.
 3. Build the project:
    ```bash
    pnpm build
    ```
-4. Link the CLI locally (optional for development):
+4. (Optional) Link the CLI globally during development:
    ```bash
    pnpm link --global
    ```
 
 ## Usage
 
-After building, run commands via the compiled binary:
+Run commands directly from the compiled output:
 
 ```bash
-node dist/cli/index.js hello
+node dist/cli/index.js <command>
 ```
 
-Or, when linked globally:
+Or, after linking:
 
 ```bash
-deepseek hello
+deepseek <command>
 ```
 
-### Available Commands
+### Interactive Chat & Sessions
 
-- `deepseek hello` — prints `DeepSeek CLI initialized successfully` to confirm setup.
-- `deepseek test-api` — sends a `ping` message to the DeepSeek API and prints the response and tokens used.
+- `deepseek chat` — start an interactive terminal chat using the configured model. Sessions and messages are
+  persisted in the configured history directory.
+- `deepseek resume [id]` — resume a specific session by ID.
+- `deepseek resume --last` — resume the most recent session snapshot.
 
-> **Note:** `deepseek test-api` requires `DEEPSEEK_API_KEY` to be configured. Without the key, the command exits with an error.
+### Sandbox Management
+
+- `deepseek sandbox get` — print the current sandbox configuration.
+- `deepseek sandbox set <read-only|workspace-write|danger-full-access>` — change sandbox mode. The change is
+  persisted to `.deepseek/config.json` and recorded in history.
+
+### Approval Policies
+
+- `deepseek approvals get` — print the current approval policy.
+- `deepseek approvals set <untrusted|on-failure|on-request|never>` — update approval policy and log the change.
+
+### Safe Patch Application
+
+- `deepseek patch apply --file <diff>` — preview and apply a unified diff. Use `--yes` to auto-approve and
+  `--json` to emit machine-readable events. Patches are validated against sandbox policies and applied
+  atomically with backups in `.deepseek/backup/`.
+
+### Safe Command Execution
+
+- `deepseek exec "<command>"` — run a shell command inside the sandbox. Options: `--cwd`, `--timeout <ms>`,
+  `--yes`, and `--json`. Execution obeys sandbox/approval rules, captures stdout/stderr, and records
+  lifecycle events.
+
+### Configuration
+
+Runtime configuration is merged from:
+
+1. `src/config/default.json`
+2. `.deepseek/config.json` (created automatically on first change)
+3. Environment overrides (`DEEPSEEK_SANDBOX_MODE`, `DEEPSEEK_APPROVALS_POLICY`, `DEEPSEEK_EXEC_TIMEOUT_MS`,
+   `DEEPSEEK_EXEC_ENV_WHITELIST`, `DEEPSEEK_WORKSPACE_ROOT`, etc.)
+
+Key sections include API settings, logging level, history directory, sandbox options, approval policy, and
+execution defaults (timeout and environment whitelist).
+
+### History & Auditing
+
+All significant operations (session events, sandbox/approval updates, patch previews/apply/rollback, exec
+previews/start/finish) are appended as JSON Lines under the configured history directory. This enables
+reliable auditing and replay of actions.
 
 ## Development Scripts
 
-- `pnpm lint` — run ESLint across the project.
-- `pnpm lint:fix` — lint with automatic fixes.
-- `pnpm format` — format files with Prettier.
-- `pnpm test` — execute Jest (`--passWithNoTests` is enabled during early development).
+- `pnpm lint` — lint source files.
+- `pnpm lint:fix` — lint with auto fixes.
+- `pnpm format` — format the codebase with Prettier.
+- `pnpm test` — run the Jest test suite.
 - `pnpm build` — compile TypeScript sources to `dist/`.
 
 ## Project Structure
@@ -65,32 +104,30 @@ deepseek hello
 deepseek-cli/
 ├── src/
 │   ├── api/
-│   │   └── deepseekClient.ts
 │   ├── cli/
-│   │   └── index.ts
+│   │   └── commands/
 │   ├── config/
-│   │   └── default.json
+│   ├── controllers/
 │   ├── core/
+│   │   ├── approvals/
+│   │   ├── exec/
+│   │   ├── patch/
+│   │   ├── sandbox/
 │   │   ├── models/
-│   │   └── repository/
+│   │   └── services/
 │   ├── tui/
 │   │   └── components/
 │   └── utils/
-│       └── logger.ts
 ├── tests/
 ├── package.json
-├── tsconfig.json
-└── README.md
+└── tsconfig.json
 ```
 
-The architecture follows a modular, layered approach (core, CLI, TUI, API, utilities) with future expansion
-planned for domain-driven modules and UI components.
+## Testing
 
-## Git Hooks
+Unit tests cover chat controller behaviour, session persistence, and sandbox/approval flows. Run the suite
+with:
 
-Husky runs lint-staged on each commit to ensure staged files are linted and formatted.
-
-## Testing the API Client
-
-The CLI uses an axios-based client (`DeepSeekClient`) that interacts with the DeepSeek chat completion
-endpoint using the configured model and base URL. The client validates responses and surfaces token usage.
+```bash
+pnpm test
+```

--- a/src/cli/commands/approvals.ts
+++ b/src/cli/commands/approvals.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import { Command } from 'commander';
+
+import { getApprovalsConfig, getHistoryDir, updateConfig } from '../../config';
+import { ApprovalPolicy } from '../../core/approvals/approvalsPolicy';
+import { HistoryLogger } from '../../core/services/historyLogger';
+
+function getHistoryLogger(): HistoryLogger {
+  const historyDir = path.resolve(process.cwd(), getHistoryDir());
+  return new HistoryLogger(historyDir);
+}
+
+function validatePolicy(policy: string): policy is ApprovalPolicy {
+  return policy === 'untrusted' || policy === 'on-failure' || policy === 'on-request' || policy === 'never';
+}
+
+export const approvals = new Command('approvals')
+  .description('manage approval policy')
+  .addCommand(
+    new Command('get')
+      .description('print current approval policy')
+      .action(() => {
+        const config = getApprovalsConfig();
+        console.log(config.policy);
+      }),
+  )
+  .addCommand(
+    new Command('set')
+      .description('update approval policy')
+      .argument('<policy>', 'approval policy: untrusted | on-failure | on-request | never')
+      .action(async (policy: string) => {
+        if (!validatePolicy(policy)) {
+          console.error('Invalid approval policy. Use one of: untrusted, on-failure, on-request, never');
+          process.exitCode = 1;
+          return;
+        }
+        const current = getApprovalsConfig();
+        if (current.policy === policy) {
+          console.log(`Approval policy already set to ${policy}`);
+          return;
+        }
+        updateConfig({ approvals: { ...current, policy } });
+        console.log(`Approval policy updated to ${policy}`);
+        await getHistoryLogger().log({ type: 'approvals.set', policy });
+      }),
+  );

--- a/src/cli/commands/exec.ts
+++ b/src/cli/commands/exec.ts
@@ -1,0 +1,100 @@
+import path from 'path';
+import { Command } from 'commander';
+
+import { getApprovalsConfig, getExecConfig, getHistoryDir, getSandboxConfig } from '../../config';
+import { Approvals } from '../../core/approvals/approvalsPolicy';
+import { runSafe } from '../../core/exec/runner';
+import { SandboxPolicy } from '../../core/sandbox/sandboxPolicy';
+import { HistoryLogger } from '../../core/services/historyLogger';
+
+export const execCommand = new Command('exec')
+  .description('execute command within sandbox constraints')
+  .argument('<command...>', 'command to execute')
+  .option('--cwd <dir>', 'working directory')
+  .option('--timeout <ms>', 'timeout in milliseconds')
+  .option('--yes', 'auto approve execution')
+  .option('--json', 'emit JSON lines output')
+  .action(async (commandParts: string[], options: { cwd?: string; timeout?: string; yes?: boolean; json?: boolean }) => {
+    const { cwd, timeout, yes, json } = options;
+    const command = commandParts.join(' ');
+    const sandboxConfig = getSandboxConfig();
+    const approvalsConfig = getApprovalsConfig();
+    const execConfig = getExecConfig();
+    const historyDir = path.resolve(process.cwd(), getHistoryDir());
+    const historyLogger = new HistoryLogger(historyDir);
+    const workspaceRoot = path.resolve(process.cwd(), sandboxConfig.workspaceRoot);
+    const sandbox = new SandboxPolicy({ ...sandboxConfig, workspaceRoot });
+    const approvals = new Approvals(approvalsConfig.policy);
+    const timeoutMs = timeout ? Number.parseInt(timeout, 10) : execConfig.timeoutMs;
+    if (Number.isNaN(timeoutMs)) {
+      console.error('Invalid timeout value');
+      process.exitCode = 1;
+      return;
+    }
+    const resolvedCwd = cwd ? path.resolve(process.cwd(), cwd) : workspaceRoot;
+    const preview = {
+      command,
+      cwd: resolvedCwd,
+      timeoutMs,
+      envWhitelist: execConfig.envWhitelist,
+    };
+
+    if (json) {
+      console.log(JSON.stringify({ type: 'exec.preview', preview }));
+    } else {
+      console.log(`Command: ${command}`);
+      console.log(`cwd: ${resolvedCwd}`);
+      console.log(`timeout: ${timeoutMs}ms`);
+    }
+
+    try {
+      const result = await runSafe(command, {
+        sandbox,
+        approvals,
+        cwd: resolvedCwd,
+        timeoutMs,
+        envWhitelist: execConfig.envWhitelist,
+        autoApprove: yes,
+        historyLogger: (event) => historyLogger.log(event),
+      });
+
+      if (json) {
+        console.log(
+          JSON.stringify({
+            type: 'exec.result',
+            ran: result.ran,
+            code: result.code,
+            stdout: result.stdout,
+            stderr: result.stderr,
+            durationMs: result.durationMs,
+            timedOut: result.timedOut,
+          }),
+        );
+      } else if (!result.ran) {
+        console.log('Command execution was not approved');
+      } else {
+        console.log(`Exit code: ${result.code}`);
+        if (result.stdout.trim()) {
+          console.log('stdout:\n' + result.stdout);
+        }
+        if (result.stderr.trim()) {
+          console.log('stderr:\n' + result.stderr);
+        }
+        if (result.timedOut) {
+          console.log('Command timed out');
+        }
+      }
+
+      if (result.ran && result.code !== 0) {
+        process.exitCode = result.code ?? 1;
+      }
+    } catch (error) {
+      const err = error as Error;
+      if (json) {
+        console.log(JSON.stringify({ type: 'exec.error', message: err.message }));
+      } else {
+        console.error('Failed to execute command:', err.message);
+      }
+      process.exitCode = 1;
+    }
+  });

--- a/src/cli/commands/patchApply.ts
+++ b/src/cli/commands/patchApply.ts
@@ -1,0 +1,76 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Command } from 'commander';
+
+import { getApprovalsConfig, getHistoryDir, getSandboxConfig } from '../../config';
+import { Approvals } from '../../core/approvals/approvalsPolicy';
+import { applyPatch } from '../../core/patch/apply';
+import { SandboxPolicy } from '../../core/sandbox/sandboxPolicy';
+import { HistoryLogger } from '../../core/services/historyLogger';
+
+async function readDiff(file?: string): Promise<string> {
+  if (file) {
+    return fs.readFile(file, 'utf-8');
+  }
+  return new Promise<string>((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+export const patchApply = new Command('patch')
+  .description('operations with patches')
+  .addCommand(
+    new Command('apply')
+      .description('apply patch from diff file or stdin')
+      .option('--file <path>', 'path to diff file')
+      .option('--yes', 'auto approve patch application')
+      .option('--json', 'emit JSON lines')
+      .action(async (options: { file?: string; yes?: boolean; json?: boolean }) => {
+        const { file, yes, json } = options;
+        const diff = await readDiff(file);
+        if (!diff.trim()) {
+          console.error('No diff content provided');
+          process.exitCode = 1;
+          return;
+        }
+        const sandboxConfig = getSandboxConfig();
+        const approvalsConfig = getApprovalsConfig();
+        const historyDir = path.resolve(process.cwd(), getHistoryDir());
+        const historyLogger = new HistoryLogger(historyDir);
+        const workspaceRoot = path.resolve(process.cwd(), sandboxConfig.workspaceRoot);
+        const sandbox = new SandboxPolicy({ ...sandboxConfig, workspaceRoot });
+        const approvals = new Approvals(approvalsConfig.policy);
+
+        try {
+          const result = await applyPatch(diff, {
+            sandbox,
+            approvals,
+            workspaceRoot,
+            autoYes: yes,
+            historyLogger: (event) => historyLogger.log(event),
+          });
+
+          if (json) {
+            console.log(JSON.stringify({ type: 'patch.preview', preview: result.preview }));
+            console.log(JSON.stringify({ type: 'patch.result', applied: result.applied }));
+          } else {
+            console.log(`Patch preview: ${result.preview.files.length} files (+${result.preview.totalAdditions} / -${result.preview.totalDeletions})`);
+            console.log(result.applied ? 'Patch applied successfully' : 'Patch application cancelled');
+          }
+        } catch (error) {
+          const err = error as Error;
+          if (json) {
+            console.log(JSON.stringify({ type: 'patch.error', message: err.message }));
+          } else {
+            console.error('Failed to apply patch:', err.message);
+          }
+          process.exitCode = 1;
+        }
+      }),
+  );

--- a/src/cli/commands/sandbox.ts
+++ b/src/cli/commands/sandbox.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import { Command } from 'commander';
+
+import { getHistoryDir, getSandboxConfig, updateConfig } from '../../config';
+import { SandboxMode } from '../../core/sandbox/types';
+import { HistoryLogger } from '../../core/services/historyLogger';
+
+function getHistoryLogger(): HistoryLogger {
+  const historyDir = path.resolve(process.cwd(), getHistoryDir());
+  return new HistoryLogger(historyDir);
+}
+
+function validateMode(mode: string): mode is SandboxMode {
+  return mode === 'read-only' || mode === 'workspace-write' || mode === 'danger-full-access';
+}
+
+export const sandbox = new Command('sandbox')
+  .description('inspect and change sandbox mode')
+  .addCommand(
+    new Command('get')
+      .description('print current sandbox configuration')
+      .action(() => {
+        const config = getSandboxConfig();
+        console.log(JSON.stringify(config, null, 2));
+      }),
+  )
+  .addCommand(
+    new Command('set')
+      .description('update sandbox mode')
+      .argument('<mode>', 'sandbox mode: read-only | workspace-write | danger-full-access')
+      .action(async (mode: string) => {
+        if (!validateMode(mode)) {
+          console.error('Invalid sandbox mode. Use one of: read-only, workspace-write, danger-full-access');
+          process.exitCode = 1;
+          return;
+        }
+        const current = getSandboxConfig();
+        if (current.mode === mode) {
+          console.log(`Sandbox mode already set to ${mode}`);
+          return;
+        }
+        updateConfig({ sandbox: { ...current, mode } });
+        console.log(`Sandbox mode updated to ${mode}`);
+        await getHistoryLogger().log({ type: 'sandbox.set', mode });
+      }),
+  );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,8 +2,12 @@
 import { Command } from 'commander';
 import dotenv from 'dotenv';
 
+import { approvals } from './commands/approvals';
 import { chat } from './commands/chat';
+import { execCommand } from './commands/exec';
+import { patchApply } from './commands/patchApply';
 import { resume } from './commands/resume';
+import { sandbox } from './commands/sandbox';
 import { logger } from '../utils/logger';
 
 dotenv.config();
@@ -13,6 +17,10 @@ const program = new Command();
 program.name('deepseek').description('DeepSeek command line interface').version('0.1.0');
 program.addCommand(chat);
 program.addCommand(resume);
+program.addCommand(sandbox);
+program.addCommand(approvals);
+program.addCommand(patchApply);
+program.addCommand(execCommand);
 
 program.parseAsync(process.argv).catch((error: unknown) => {
   const err = error as Error;

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -6,5 +6,18 @@
   "logging": {
     "level": "debug"
   },
-  "historyDir": "history"
+  "historyDir": "history",
+  "sandbox": {
+    "mode": "read-only",
+    "workspaceRoot": ".",
+    "writableRoots": ["./tmp"],
+    "allowDeepSeekOnly": true
+  },
+  "approvals": {
+    "policy": "untrusted"
+  },
+  "exec": {
+    "timeoutMs": 120000,
+    "envWhitelist": ["PATH", "HOME", "SHELL", "TMPDIR"]
+  }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,9 @@
+import fs from 'fs';
+import path from 'path';
+
 import defaultConfig from './default.json';
+import { SandboxConfig, SandboxMode } from '../core/sandbox/types';
+import { ApprovalPolicy } from '../core/approvals/approvalsPolicy';
 
 export interface LoggingConfig {
   level: string;
@@ -9,18 +14,123 @@ export interface ApiConfig {
   model: string;
 }
 
+export interface ApprovalsConfig {
+  policy: ApprovalPolicy;
+}
+
+export interface ExecConfig {
+  timeoutMs: number;
+  envWhitelist: string[];
+}
+
 export interface AppConfig {
   api: ApiConfig;
   logging: LoggingConfig;
   historyDir: string;
+  sandbox: SandboxConfig;
+  approvals: ApprovalsConfig;
+  exec: ExecConfig;
 }
 
-const appConfig: AppConfig = defaultConfig as AppConfig;
+const CONFIG_PATH = path.resolve(process.cwd(), '.deepseek', 'config.json');
 
-export const getConfig = (): AppConfig => appConfig;
+let cachedConfig: AppConfig | null = null;
 
-export const getApiConfig = (): ApiConfig => appConfig.api;
+function deepMerge<T>(target: T, source: Partial<T>): T {
+  const result: Record<string, unknown> = Array.isArray(target) ? [...(target as unknown[])] : { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) {
+      continue;
+    }
+    const current = (result as Record<string, unknown>)[key];
+    if (Array.isArray(value)) {
+      (result as Record<string, unknown>)[key] = [...value];
+    } else if (value && typeof value === 'object' && current && typeof current === 'object' && !Array.isArray(current)) {
+      (result as Record<string, unknown>)[key] = deepMerge(current, value as Record<string, unknown>);
+    } else {
+      (result as Record<string, unknown>)[key] = value;
+    }
+  }
+  return result as T;
+}
 
-export const getLoggingConfig = (): LoggingConfig => appConfig.logging;
+function readUserConfig(): Partial<AppConfig> {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    return JSON.parse(raw) as Partial<AppConfig>;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
 
-export const getHistoryDir = (): string => appConfig.historyDir;
+function applyEnvOverrides(config: AppConfig): AppConfig {
+  const result = { ...config };
+  const sandboxMode = process.env.DEEPSEEK_SANDBOX_MODE as SandboxMode | undefined;
+  if (sandboxMode) {
+    result.sandbox = { ...result.sandbox, mode: sandboxMode };
+  }
+  const approvalsPolicy = process.env.DEEPSEEK_APPROVALS_POLICY as ApprovalPolicy | undefined;
+  if (approvalsPolicy) {
+    result.approvals = { ...result.approvals, policy: approvalsPolicy };
+  }
+  const execTimeout = process.env.DEEPSEEK_EXEC_TIMEOUT_MS;
+  if (execTimeout) {
+    const parsed = Number.parseInt(execTimeout, 10);
+    if (!Number.isNaN(parsed)) {
+      result.exec = { ...result.exec, timeoutMs: parsed };
+    }
+  }
+  const envWhitelist = process.env.DEEPSEEK_EXEC_ENV_WHITELIST;
+  if (envWhitelist) {
+    result.exec = { ...result.exec, envWhitelist: envWhitelist.split(',').map((item) => item.trim()).filter(Boolean) };
+  }
+  const workspaceRoot = process.env.DEEPSEEK_WORKSPACE_ROOT;
+  if (workspaceRoot) {
+    result.sandbox = { ...result.sandbox, workspaceRoot };
+  }
+  return result;
+}
+
+function loadConfig(): AppConfig {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+  const merged = deepMerge(defaultConfig as AppConfig, readUserConfig());
+  cachedConfig = applyEnvOverrides(merged);
+  return cachedConfig;
+}
+
+function ensureConfigDir() {
+  const dir = path.dirname(CONFIG_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function updateConfig(partial: Partial<AppConfig>) {
+  const current = deepMerge(defaultConfig as AppConfig, readUserConfig());
+  const updated = deepMerge(current, partial);
+  ensureConfigDir();
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(updated, null, 2), 'utf-8');
+  cachedConfig = applyEnvOverrides(updated as AppConfig);
+}
+
+export const getConfig = (): AppConfig => loadConfig();
+
+export const getApiConfig = (): ApiConfig => loadConfig().api;
+
+export const getLoggingConfig = (): LoggingConfig => loadConfig().logging;
+
+export const getHistoryDir = (): string => loadConfig().historyDir;
+
+export const getSandboxConfig = (): SandboxConfig => loadConfig().sandbox;
+
+export const getApprovalsConfig = (): ApprovalsConfig => loadConfig().approvals;
+
+export const getExecConfig = (): ExecConfig => loadConfig().exec;
+
+export const getConfigPath = (): string => CONFIG_PATH;

--- a/src/core/approvals/approvalsPolicy.ts
+++ b/src/core/approvals/approvalsPolicy.ts
@@ -1,0 +1,36 @@
+export type ApprovalPolicy = 'untrusted' | 'on-failure' | 'on-request' | 'never';
+
+export type ApprovalKind = 'patch' | 'exec' | 'net';
+
+export class Approvals {
+  constructor(private policy: ApprovalPolicy) {}
+
+  setPolicy(policy: ApprovalPolicy) {
+    this.policy = policy;
+  }
+
+  getPolicy(): ApprovalPolicy {
+    return this.policy;
+  }
+
+  needsApproval(kind: ApprovalKind): boolean {
+    if (this.policy === 'never') {
+      return false;
+    }
+
+    if (this.policy === 'untrusted') {
+      return true;
+    }
+
+    if (this.policy === 'on-request') {
+      return false;
+    }
+
+    if (this.policy === 'on-failure') {
+      return false;
+    }
+
+    // default conservative behaviour
+    return true;
+  }
+}

--- a/src/core/approvals/prompts.ts
+++ b/src/core/approvals/prompts.ts
@@ -1,0 +1,22 @@
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+export interface PromptOptions {
+  autoYes?: boolean;
+  message: string;
+}
+
+export async function promptApproval({ autoYes, message }: PromptOptions): Promise<boolean> {
+  if (autoYes) {
+    return true;
+  }
+
+  const rl = readline.createInterface({ input, output });
+  try {
+    const answer = await rl.question(`${message} [y/N] `);
+    const normalized = answer.trim().toLowerCase();
+    return normalized === 'y' || normalized === 'yes';
+  } finally {
+    rl.close();
+  }
+}

--- a/src/core/exec/envPolicy.ts
+++ b/src/core/exec/envPolicy.ts
@@ -1,0 +1,17 @@
+export interface EnvPolicyOptions {
+  whitelist: string[];
+}
+
+export function buildEnv(allowed: string[], source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {};
+  for (const key of allowed) {
+    if (key in source) {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+export function filterEnv(policy: EnvPolicyOptions, source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return buildEnv(policy.whitelist, source);
+}

--- a/src/core/exec/runner.ts
+++ b/src/core/exec/runner.ts
@@ -1,0 +1,127 @@
+import { spawn } from 'node:child_process';
+import path from 'path';
+
+import { Approvals } from '../approvals/approvalsPolicy';
+import { promptApproval } from '../approvals/prompts';
+import { SandboxPolicy } from '../sandbox/sandboxPolicy';
+import { filterEnv } from './envPolicy';
+
+export interface ExecOptions {
+  cwd?: string;
+  timeoutMs?: number;
+  envWhitelist?: string[];
+  autoApprove?: boolean;
+  sandbox: SandboxPolicy;
+  approvals: Approvals;
+  historyLogger?: (event: Record<string, unknown>) => Promise<void>;
+}
+
+export interface ExecResult {
+  ran: boolean;
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+function resolveCwd(options: ExecOptions): string {
+  const cwd = options.cwd ?? options.sandbox.paths.workspaceRoot;
+  return path.resolve(cwd);
+}
+
+export async function runSafe(cmd: string, opts: ExecOptions): Promise<ExecResult> {
+  const cwd = resolveCwd(opts);
+  const preview = {
+    command: cmd,
+    cwd,
+    timeoutMs: opts.timeoutMs,
+    envWhitelist: opts.envWhitelist,
+  };
+
+  if (opts.historyLogger) {
+    await opts.historyLogger({ type: 'exec.preview', preview });
+  }
+
+  const requiresApproval = opts.approvals.needsApproval('exec');
+  const requiresOverride = opts.sandbox.mode === 'read-only';
+
+  let approved = Boolean(opts.autoApprove);
+  if ((requiresApproval || requiresOverride) && !approved) {
+    const confirmed = await promptApproval({
+      autoYes: opts.autoApprove,
+      message: `Execute command: "${cmd}"? cwd=${cwd} timeout=${opts.timeoutMs ?? 'default'}`,
+    });
+    if (!confirmed) {
+      return { ran: false, code: null, stdout: '', stderr: '', durationMs: 0, timedOut: false };
+    }
+    approved = true;
+  }
+
+  opts.sandbox.assertExecAllowed({ cwd, override: approved });
+
+  const env = opts.envWhitelist ? filterEnv({ whitelist: opts.envWhitelist }, process.env) : process.env;
+
+  if (opts.historyLogger) {
+    await opts.historyLogger({ type: 'exec.started', command: cmd, cwd });
+  }
+
+  return new Promise<ExecResult>((resolve, reject) => {
+    const start = Date.now();
+    const child = spawn(cmd, {
+      shell: true,
+      cwd,
+      env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timeout = opts.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGTERM');
+        }, opts.timeoutMs)
+      : null;
+
+    const finalize = async (result: ExecResult, error?: Error) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (opts.historyLogger) {
+        await opts.historyLogger({
+          type: 'exec.finished',
+          command: cmd,
+          cwd,
+          code: result.code,
+          durationMs: result.durationMs,
+          timedOut: result.timedOut,
+          error: error ? error.message : undefined,
+        });
+      }
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    };
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      const durationMs = Date.now() - start;
+      void finalize({ ran: true, code: null, stdout, stderr, durationMs, timedOut }, error as Error);
+    });
+
+    child.on('close', (code) => {
+      const durationMs = Date.now() - start;
+      void finalize({ ran: true, code, stdout, stderr, durationMs, timedOut });
+    });
+  });
+}

--- a/src/core/patch/apply.ts
+++ b/src/core/patch/apply.ts
@@ -1,0 +1,196 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { Approvals } from '../approvals/approvalsPolicy';
+import { promptApproval } from '../approvals/prompts';
+import { SandboxPolicy } from '../sandbox/sandboxPolicy';
+import { FileDiff, parseUnifiedDiff } from './parseUnifiedDiff';
+import { buildPreview, PatchPreview } from './preview';
+
+export interface ApplyPatchResult {
+  applied: boolean;
+  preview: PatchPreview;
+  backupDir?: string;
+}
+
+export interface ApplyPatchContext {
+  sandbox: SandboxPolicy;
+  approvals: Approvals;
+  workspaceRoot: string;
+  autoYes?: boolean;
+  historyLogger?: (event: Record<string, unknown>) => Promise<void>;
+}
+
+interface FileApplyResult {
+  path: string;
+  newContent: string | null;
+}
+
+function ensureDir(filePath: string) {
+  return fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function readFileIfExists(target: string): Promise<string | null> {
+  try {
+    return await fs.readFile(target, 'utf-8');
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function applyFileDiff(diff: FileDiff, originalContent: string | null): string | null {
+  const originalLines = originalContent?.split('\n') ?? [];
+  const resultLines: string[] = [];
+  let cursor = 1;
+
+  for (const hunk of diff.hunks) {
+    const copyUntil = hunk.oldStart - 1;
+    while (cursor <= copyUntil && cursor - 1 < originalLines.length) {
+      resultLines.push(originalLines[cursor - 1]);
+      cursor += 1;
+    }
+
+    let originalIndex = hunk.oldStart - 1;
+    for (const line of hunk.lines) {
+      if (line.type === 'context') {
+        const expected = originalLines[originalIndex] ?? '';
+        if (expected !== line.value) {
+          throw new Error(`Context mismatch while applying patch for ${diff.path}`);
+        }
+        resultLines.push(line.value);
+        originalIndex += 1;
+        cursor = originalIndex + 1;
+      } else if (line.type === 'remove') {
+        const expected = originalLines[originalIndex] ?? '';
+        if (expected !== line.value) {
+          throw new Error(`Removal mismatch while applying patch for ${diff.path}`);
+        }
+        originalIndex += 1;
+        cursor = originalIndex + 1;
+      } else if (line.type === 'add') {
+        resultLines.push(line.value);
+      }
+    }
+
+    cursor = originalIndex + 1;
+  }
+
+  while (cursor - 1 < originalLines.length) {
+    resultLines.push(originalLines[cursor - 1]);
+    cursor += 1;
+  }
+
+  if (diff.isDeleted) {
+    return null;
+  }
+
+  return resultLines.join('\n');
+}
+
+async function backupFile(workspaceRoot: string, target: string, backupRoot: string) {
+  const content = await readFileIfExists(target);
+  if (content === null) {
+    return;
+  }
+  const relativePath = path.relative(workspaceRoot, target);
+  const backupPath = path.join(backupRoot, relativePath);
+  await fs.mkdir(path.dirname(backupPath), { recursive: true });
+  await fs.writeFile(backupPath, content, 'utf-8');
+}
+
+async function copyBackupDir(source: string, destination: string) {
+  const entries = await fs.readdir(source, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const srcPath = path.join(source, entry.name);
+    const destPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      await copyBackupDir(srcPath, destPath);
+    } else {
+      await fs.mkdir(path.dirname(destPath), { recursive: true });
+      const content = await fs.readFile(srcPath, 'utf-8');
+      await fs.writeFile(destPath, content, 'utf-8');
+    }
+  }
+}
+
+async function restoreFromBackup(backupRoot: string, workspaceRoot: string) {
+  await copyBackupDir(backupRoot, workspaceRoot);
+}
+
+async function applySingleFile(workspaceRoot: string, diff: FileDiff): Promise<FileApplyResult> {
+  const target = path.resolve(workspaceRoot, diff.path);
+  const original = await readFileIfExists(target);
+  const updated = applyFileDiff(diff, original);
+
+  if (updated === null) {
+    await fs.rm(target, { force: true });
+    return { path: diff.path, newContent: null };
+  }
+
+  await ensureDir(target);
+  await fs.writeFile(target, updated, 'utf-8');
+  return { path: diff.path, newContent: updated };
+}
+
+export async function applyPatch(diffText: string, ctx: ApplyPatchContext): Promise<ApplyPatchResult> {
+  const diffs = parseUnifiedDiff(diffText);
+  const preview = buildPreview(diffs);
+  const { sandbox, approvals, workspaceRoot, autoYes, historyLogger } = ctx;
+
+  if (historyLogger) {
+    await historyLogger({ type: 'patch.preview', preview });
+  }
+
+  for (const file of diffs) {
+    const target = path.resolve(workspaceRoot, file.path);
+    sandbox.assertWriteAllowed(target);
+  }
+
+  if (approvals.needsApproval('patch')) {
+    const confirmed = await promptApproval({
+      autoYes,
+      message: `Apply patch for ${preview.files.length} files (+${preview.totalAdditions} / -${preview.totalDeletions})?`,
+    });
+    if (!confirmed) {
+      return { applied: false, preview };
+    }
+  }
+
+  const backupRoot = path.join(workspaceRoot, '.deepseek', 'backup', Date.now().toString());
+  await fs.mkdir(backupRoot, { recursive: true });
+
+  try {
+    for (const file of diffs) {
+      const target = path.resolve(workspaceRoot, file.path);
+      await backupFile(workspaceRoot, target, backupRoot);
+    }
+
+    const appliedFiles: FileApplyResult[] = [];
+    for (const file of diffs) {
+      const result = await applySingleFile(workspaceRoot, file);
+      appliedFiles.push(result);
+    }
+
+    if (historyLogger) {
+      await historyLogger({ type: 'patch.applied', files: appliedFiles.map((f) => f.path) });
+    }
+
+    return { applied: true, preview, backupDir: backupRoot };
+  } catch (error) {
+    for (const file of diffs) {
+      const target = path.resolve(workspaceRoot, file.path);
+      if (file.isNew) {
+        await fs.rm(target, { force: true }).catch(() => undefined);
+      }
+    }
+    await restoreFromBackup(backupRoot, workspaceRoot).catch(() => undefined);
+    if (historyLogger) {
+      await historyLogger({ type: 'patch.rollback', error: (error as Error).message });
+    }
+    throw error;
+  }
+}

--- a/src/core/patch/parseUnifiedDiff.ts
+++ b/src/core/patch/parseUnifiedDiff.ts
@@ -1,0 +1,119 @@
+export interface HunkLine {
+  type: 'context' | 'add' | 'remove';
+  value: string;
+}
+
+export interface Hunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: HunkLine[];
+}
+
+export interface FileDiff {
+  path: string;
+  hunks: Hunk[];
+  isNew: boolean;
+  isDeleted: boolean;
+}
+
+function parseHunkHeader(header: string) {
+  const match = /@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(header);
+  if (!match) {
+    throw new Error(`Invalid hunk header: ${header}`);
+  }
+
+  return {
+    oldStart: Number.parseInt(match[1], 10),
+    oldLines: match[2] ? Number.parseInt(match[2], 10) : 1,
+    newStart: Number.parseInt(match[3], 10),
+    newLines: match[4] ? Number.parseInt(match[4], 10) : 1,
+  };
+}
+
+function sanitizePath(raw: string): string {
+  const trimmed = raw.replace(/^a\//, '').replace(/^b\//, '');
+  return trimmed;
+}
+
+export function parseUnifiedDiff(input: string): FileDiff[] {
+  const lines = input.replace(/\r\n/g, '\n').split('\n');
+  const files: FileDiff[] = [];
+  let current: FileDiff | null = null;
+  let pendingHeader: { oldPath?: string; newPath?: string } | null = null;
+
+  const pushCurrent = () => {
+    if (current) {
+      files.push(current);
+      current = null;
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      pushCurrent();
+      pendingHeader = null;
+      continue;
+    }
+
+    if (line.startsWith('--- ')) {
+      pendingHeader = pendingHeader ?? {};
+      const oldPath = line.slice(4).trim();
+      pendingHeader.oldPath = oldPath === '/dev/null' ? undefined : sanitizePath(oldPath);
+      continue;
+    }
+
+    if (line.startsWith('+++ ')) {
+      pendingHeader = pendingHeader ?? {};
+      const newPath = line.slice(4).trim();
+      pendingHeader.newPath = newPath === '/dev/null' ? undefined : sanitizePath(newPath);
+      const pathValue = pendingHeader.newPath ?? pendingHeader.oldPath;
+      if (!pathValue) {
+        throw new Error('Unable to determine file path from diff headers');
+      }
+      current = {
+        path: pathValue,
+        hunks: [],
+        isNew: pendingHeader.oldPath === undefined && pendingHeader.newPath !== undefined,
+        isDeleted: pendingHeader.newPath === undefined && pendingHeader.oldPath !== undefined,
+      };
+      continue;
+    }
+
+    if (line.startsWith('@@')) {
+      if (!current) {
+        throw new Error('Found hunk header before file header');
+      }
+      const { oldStart, oldLines, newStart, newLines } = parseHunkHeader(line);
+      current.hunks.push({ oldStart, oldLines, newStart, newLines, lines: [] });
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (!current.hunks.length) {
+      continue;
+    }
+
+    const hunk = current.hunks[current.hunks.length - 1];
+
+    if (line.startsWith('+')) {
+      hunk.lines.push({ type: 'add', value: line.slice(1) });
+    } else if (line.startsWith('-')) {
+      hunk.lines.push({ type: 'remove', value: line.slice(1) });
+    } else if (line.startsWith(' ')) {
+      hunk.lines.push({ type: 'context', value: line.slice(1) });
+    } else if (line.startsWith('\\ No newline at end of file')) {
+      // ignore
+    } else if (line.trim() === '') {
+      hunk.lines.push({ type: 'context', value: '' });
+    }
+  }
+
+  pushCurrent();
+
+  return files;
+}

--- a/src/core/patch/preview.ts
+++ b/src/core/patch/preview.ts
@@ -1,0 +1,51 @@
+import { FileDiff } from './parseUnifiedDiff';
+
+export interface PatchFilePreview {
+  path: string;
+  additions: number;
+  deletions: number;
+  isNew: boolean;
+  isDeleted: boolean;
+}
+
+export interface PatchPreview {
+  files: PatchFilePreview[];
+  totalAdditions: number;
+  totalDeletions: number;
+}
+
+export function buildPreview(diffs: FileDiff[]): PatchPreview {
+  const files: PatchFilePreview[] = [];
+  let totalAdditions = 0;
+  let totalDeletions = 0;
+
+  for (const diff of diffs) {
+    let additions = 0;
+    let deletions = 0;
+    for (const hunk of diff.hunks) {
+      for (const line of hunk.lines) {
+        if (line.type === 'add') {
+          additions += 1;
+        }
+        if (line.type === 'remove') {
+          deletions += 1;
+        }
+      }
+    }
+    totalAdditions += additions;
+    totalDeletions += deletions;
+    files.push({
+      path: diff.path,
+      additions,
+      deletions,
+      isNew: diff.isNew,
+      isDeleted: diff.isDeleted,
+    });
+  }
+
+  return {
+    files,
+    totalAdditions,
+    totalDeletions,
+  };
+}

--- a/src/core/sandbox/sandboxPolicy.ts
+++ b/src/core/sandbox/sandboxPolicy.ts
@@ -1,0 +1,107 @@
+import path from 'path';
+
+import { SandboxConfig, SandboxMode, SandboxPaths, ExecValidationOptions } from './types';
+
+export class SandboxViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SandboxViolationError';
+  }
+}
+
+export class SandboxPolicy {
+  private readonly workspaceRoot: string;
+  private readonly writableRoots: string[];
+
+  constructor(private readonly cfg: SandboxConfig) {
+    this.workspaceRoot = path.resolve(cfg.workspaceRoot);
+    this.writableRoots = (cfg.writableRoots ?? []).map((root) => path.resolve(root));
+  }
+
+  get mode(): SandboxMode {
+    return this.cfg.mode;
+  }
+
+  get allowDeepSeekOnly(): boolean {
+    return this.cfg.allowDeepSeekOnly;
+  }
+
+  get paths(): SandboxPaths {
+    return { workspaceRoot: this.workspaceRoot, writableRoots: [...this.writableRoots] };
+  }
+
+  isInsideWorkspace(absPath: string): boolean {
+    const resolved = path.resolve(absPath);
+    return resolved === this.workspaceRoot || resolved.startsWith(`${this.workspaceRoot}${path.sep}`);
+  }
+
+  private isInsideWritableRoots(absPath: string): boolean {
+    const resolved = path.resolve(absPath);
+    return this.writableRoots.some((root) => resolved === root || resolved.startsWith(`${root}${path.sep}`));
+  }
+
+  isWriteAllowed(absPath: string): boolean {
+    const resolved = path.resolve(absPath);
+    if (this.cfg.mode === 'danger-full-access') {
+      return true;
+    }
+
+    if (this.cfg.mode === 'read-only') {
+      return false;
+    }
+
+    if (this.cfg.mode === 'workspace-write') {
+      return this.isInsideWorkspace(resolved) || this.isInsideWritableRoots(resolved);
+    }
+
+    return false;
+  }
+
+  assertWriteAllowed(absPath: string) {
+    if (!this.isWriteAllowed(absPath)) {
+      throw new SandboxViolationError(`Writing to ${absPath} is not permitted in sandbox mode ${this.cfg.mode}`);
+    }
+  }
+
+  isExecCwdAllowed(cwd: string): boolean {
+    const resolved = path.resolve(cwd);
+    if (this.cfg.mode === 'danger-full-access') {
+      return true;
+    }
+
+    if (this.cfg.mode === 'read-only') {
+      return false;
+    }
+
+    return this.isInsideWorkspace(resolved) || this.isInsideWritableRoots(resolved);
+  }
+
+  assertExecAllowed(opts: ExecValidationOptions) {
+    const { cwd, override } = opts;
+    if (this.cfg.mode === 'read-only' && !override) {
+      throw new SandboxViolationError('Execution is not allowed in read-only sandbox mode without explicit approval');
+    }
+
+    if (!this.isExecCwdAllowed(cwd)) {
+      throw new SandboxViolationError(`Execution cwd ${cwd} is not permitted in sandbox mode ${this.cfg.mode}`);
+    }
+  }
+
+  isNetworkAllowed(hostname: string): boolean {
+    if (this.cfg.mode === 'danger-full-access') {
+      return true;
+    }
+
+    if (this.cfg.allowDeepSeekOnly) {
+      return hostname.endsWith('api.deepseek.com');
+    }
+
+    return false;
+  }
+
+  assertNetworkAllowed(hostname: string) {
+    if (!this.isNetworkAllowed(hostname)) {
+      throw new SandboxViolationError(`Network access to ${hostname} is not allowed in sandbox mode ${this.cfg.mode}`);
+    }
+  }
+}

--- a/src/core/sandbox/types.ts
+++ b/src/core/sandbox/types.ts
@@ -1,0 +1,18 @@
+export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+export interface SandboxConfig {
+  mode: SandboxMode;
+  workspaceRoot: string;
+  writableRoots?: string[];
+  allowDeepSeekOnly: boolean;
+}
+
+export interface SandboxPaths {
+  workspaceRoot: string;
+  writableRoots: string[];
+}
+
+export interface ExecValidationOptions {
+  cwd: string;
+  override?: boolean;
+}

--- a/src/core/services/eventBus.ts
+++ b/src/core/services/eventBus.ts
@@ -10,11 +10,24 @@ export interface StatusEvent {
   message?: string;
 }
 
+export interface AgentPatchSuggestedEvent {
+  diff: string;
+  reason?: string;
+}
+
+export interface AgentExecSuggestedEvent {
+  command: string;
+  cwd?: string;
+  reason?: string;
+}
+
 export type ChatEventMap = {
   status: StatusEvent;
   session: Session;
   message: Message;
   error: { error: Error };
+  'agent.patch.suggested': AgentPatchSuggestedEvent;
+  'agent.exec.suggested': AgentExecSuggestedEvent;
 };
 
 type Listener<T> = (payload: T) => void;

--- a/src/core/services/historyLogger.ts
+++ b/src/core/services/historyLogger.ts
@@ -1,0 +1,16 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export class HistoryLogger {
+  constructor(private readonly historyDir: string, private readonly fileName = 'operations.jsonl') {}
+
+  private get filePath(): string {
+    return path.join(this.historyDir, this.fileName);
+  }
+
+  async log(event: Record<string, unknown>) {
+    const record = { ...event, ts: Date.now() };
+    await fs.mkdir(this.historyDir, { recursive: true });
+    await fs.appendFile(this.filePath, `${JSON.stringify(record)}\n`, 'utf-8');
+  }
+}

--- a/src/tui/components/ApprovalPrompt.tsx
+++ b/src/tui/components/ApprovalPrompt.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+export interface ApprovalPromptProps {
+  title: string;
+  details?: string;
+  danger?: boolean;
+}
+
+export function ApprovalPrompt({ title, details, danger }: ApprovalPromptProps) {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={danger ? 'red' : 'green'} paddingX={1} paddingY={0}>
+      <Text color={danger ? 'red' : 'green'}>{title}</Text>
+      {details ? <Text>{details}</Text> : null}
+      <Text>Confirm? [y/N]</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/ExecPreview.tsx
+++ b/src/tui/components/ExecPreview.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+export interface ExecPreviewProps {
+  command: string;
+  cwd: string;
+  timeoutMs: number;
+  envWhitelist: string[];
+}
+
+export function ExecPreview({ command, cwd, timeoutMs, envWhitelist }: ExecPreviewProps) {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="magenta" paddingX={1}>
+      <Text>Execute: {command}</Text>
+      <Text>cwd: {cwd}</Text>
+      <Text>timeout: {timeoutMs}ms</Text>
+      <Text>env whitelist: {envWhitelist.join(', ') || 'none'}</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/PatchPreview.tsx
+++ b/src/tui/components/PatchPreview.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+import { PatchPreview as PatchPreviewData } from '../../core/patch/preview';
+
+export interface PatchPreviewProps {
+  preview: PatchPreviewData;
+}
+
+export function PatchPreview({ preview }: PatchPreviewProps) {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Text>Patch changes: {preview.files.length} files (+{preview.totalAdditions} / -{preview.totalDeletions})</Text>
+      {preview.files.map((file) => (
+        <Text key={file.path}>
+          {file.path} {file.isNew ? '[new]' : ''} {file.isDeleted ? '[deleted]' : ''} (+{file.additions} / -{file.deletions})
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/tests/securityFlows.test.ts
+++ b/tests/securityFlows.test.ts
@@ -1,0 +1,106 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { Approvals } from '../src/core/approvals/approvalsPolicy';
+import { applyPatch } from '../src/core/patch/apply';
+import { buildPreview } from '../src/core/patch/preview';
+import { parseUnifiedDiff } from '../src/core/patch/parseUnifiedDiff';
+import { runSafe } from '../src/core/exec/runner';
+import { SandboxPolicy } from '../src/core/sandbox/sandboxPolicy';
+import { SandboxConfig } from '../src/core/sandbox/types';
+
+function createSandbox(config: Partial<SandboxConfig> = {}, workspaceRoot?: string) {
+  const root = workspaceRoot ?? process.cwd();
+  return new SandboxPolicy({
+    mode: 'read-only',
+    workspaceRoot: root,
+    allowDeepSeekOnly: true,
+    ...config,
+  });
+}
+
+async function withTempWorkspace(fn: (workspace: string) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ds-cli-test-'));
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('SandboxPolicy', () => {
+  test('disallows writes in read-only mode', async () => {
+    await withTempWorkspace(async (workspace) => {
+      const sandbox = createSandbox({ mode: 'read-only', workspaceRoot: workspace });
+      expect(sandbox.isWriteAllowed(path.join(workspace, 'file.txt'))).toBe(false);
+    });
+  });
+
+  test('allows workspace writes in workspace-write mode', async () => {
+    await withTempWorkspace(async (workspace) => {
+      const sandbox = createSandbox({ mode: 'workspace-write', workspaceRoot: workspace });
+      expect(sandbox.isWriteAllowed(path.join(workspace, 'file.txt'))).toBe(true);
+      expect(sandbox.isWriteAllowed(path.join(path.dirname(workspace), 'outside.txt'))).toBe(false);
+    });
+  });
+
+  test('allows all writes in danger-full-access mode', async () => {
+    await withTempWorkspace(async (workspace) => {
+      const sandbox = createSandbox({ mode: 'danger-full-access', workspaceRoot: workspace });
+      expect(sandbox.isWriteAllowed(path.join(workspace, 'file.txt'))).toBe(true);
+      expect(sandbox.isWriteAllowed(path.join('/', 'tmp', 'other.txt'))).toBe(true);
+    });
+  });
+});
+
+describe('Patch application', () => {
+  const diff = `diff --git a/example.txt b/example.txt\n` +
+    `--- a/example.txt\n` +
+    `+++ b/example.txt\n` +
+    `@@ -0,0 +1 @@\n` +
+    `+hello world\n`;
+
+  test('buildPreview counts additions', () => {
+    const parsed = parseUnifiedDiff(diff);
+    const preview = buildPreview(parsed);
+    expect(preview.totalAdditions).toBe(1);
+    expect(preview.totalDeletions).toBe(0);
+    expect(preview.files[0].isNew).toBe(true);
+  });
+
+  test('applyPatch writes files and respects sandbox', async () => {
+    await withTempWorkspace(async (workspace) => {
+      const sandbox = createSandbox({ mode: 'workspace-write', workspaceRoot: workspace });
+      const approvals = new Approvals('never');
+      const result = await applyPatch(diff, {
+        sandbox,
+        approvals,
+        workspaceRoot: workspace,
+        historyLogger: () => Promise.resolve(),
+      });
+      expect(result.applied).toBe(true);
+      const content = await fs.readFile(path.join(workspace, 'example.txt'), 'utf-8');
+      expect(content.trim()).toBe('hello world');
+    });
+  });
+});
+
+describe('runSafe', () => {
+  test('executes command inside sandbox', async () => {
+    await withTempWorkspace(async (workspace) => {
+      const sandbox = createSandbox({ mode: 'workspace-write', workspaceRoot: workspace });
+      const approvals = new Approvals('never');
+      const result = await runSafe('echo test-run-safe', {
+        sandbox,
+        approvals,
+        cwd: workspace,
+        timeoutMs: 1000,
+        envWhitelist: ['PATH'],
+        autoApprove: true,
+      });
+      expect(result.ran).toBe(true);
+      expect(result.stdout).toContain('test-run-safe');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add sandbox, approvals, patch, and exec core modules with history logging hooks
- expose sandbox/approval management plus safe patch and exec commands in the CLI and update configuration handling
- document the new flows and extend the TUI/test suite for sandbox and execution scenarios

## Testing
- pnpm test *(fails: jest binary not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e18e1ca8e8832396032f04d9029372